### PR TITLE
Make cast/1 accepts atom keys and integer values

### DIFF
--- a/lib/ecto_interval.ex
+++ b/lib/ecto_interval.ex
@@ -9,20 +9,36 @@ if Code.ensure_loaded?(Postgrex) do
     def type, do: Postgrex.Interval
 
     @impl true
-    def cast(%{"months" => months, "days" => days, "secs" => secs}) when is_binary(months) do
+    def cast(%{"months" => months, "days" => days, "secs" => secs}) do
+      do_cast(months, days, secs)
+    end
+
+    def cast(%{months: months, days: days, secs: secs}) do
+      do_cast(months, days, secs)
+    end
+
+    def cast(_) do
+      :error
+    end
+
+    defp do_cast(months, days, secs) do
       try do
-        months = String.to_integer(months)
-        days = String.to_integer(days)
-        secs = String.to_integer(secs)
+        months = to_integer(months)
+        days = to_integer(days)
+        secs = to_integer(secs)
         {:ok, %{months: months, days: days, secs: secs}}
       rescue
-        ArgumentError -> :error
+        _ -> :error
       end
     end
 
-    # def cast({months, days, seconds}) do
-    #   %{months: months, days: days, seconds: seconds}
-    # end
+    defp to_integer(arg) when is_binary(arg) do
+      String.to_integer(arg)
+    end
+
+    defp to_integer(arg) when is_integer(arg) do
+      arg
+    end
 
     @impl true
     def load(%{months: months, days: days, secs: secs}) do
@@ -30,7 +46,7 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     @impl true
-    def dump(%{:months => months, :days => days, :secs => secs}) do
+    def dump(%{months: months, days: days, secs: secs}) do
       {:ok, %Postgrex.Interval{months: months, days: days, secs: secs}}
     end
 

--- a/test/ecto_interval_test.exs
+++ b/test/ecto_interval_test.exs
@@ -2,7 +2,7 @@ defmodule EctoIntervalTest do
   use ExUnit.Case
   doctest EctoInterval
 
-  test "load" do
+  test "load/1" do
     assert {:ok, %Postgrex.Interval{months: 0, days: 0, secs: 0}} =
              EctoInterval.load(%{months: 0, days: 0, secs: 0})
 
@@ -10,7 +10,34 @@ defmodule EctoIntervalTest do
              EctoInterval.load(%{months: 1, days: 2, secs: 3})
   end
 
-  test "to_string" do
+  describe "cast/1" do
+    test "accept atom keys" do
+      {:ok, %{months: 1, days: 2, secs: 3}} =
+        EctoInterval.cast(%{months: "1", days: "2", secs: "3"})
+    end
+
+    test "accept string keys" do
+      {:ok, %{months: 1, days: 2, secs: 3}} =
+        EctoInterval.cast(%{"months" => 1, "days" => 2, "secs" => 3})
+    end
+
+    test "accept string values" do
+      {:ok, %{months: 1, days: 2, secs: 3}} =
+        EctoInterval.cast(%{"months" => "1", "days" => "2", "secs" => "3"})
+    end
+
+    test "accept integer values" do
+      {:ok, %{months: 1, days: 2, secs: 3}} = EctoInterval.cast(%{months: 1, days: 2, secs: 3})
+    end
+
+    test "return :error in other cases" do
+      :error = EctoInterval.cast(%{"months" => 1, days: 2, secs: 3})
+      :error = EctoInterval.cast(%{months: 1, days: "1 day", secs: 3})
+      :error = EctoInterval.cast(%{months: 1, days: 2, secs: :"3 sec"})
+    end
+  end
+
+  test "to_string/1" do
     {:ok, none} = EctoInterval.load(%{months: 0, days: 0, secs: 0})
     {:ok, some} = EctoInterval.load(%{months: 1, days: 2, secs: 3})
     {:ok, usual} = EctoInterval.load(%{months: 24, days: 0, secs: 0})


### PR DESCRIPTION
Hey there!
Sorry for bothering you again, but I'd like `cast/1` to also accept atoms for keys and integer for values.
It may be useful with Absinthe input objects.