### PR TITLE
chore(Ecto.Type): Ecto 3.2+ requires callbacks for custom types. If t…

### DIFF
--- a/lib/ecto_interval.ex
+++ b/lib/ecto_interval.ex
@@ -3,7 +3,11 @@ if Code.ensure_loaded?(Postgrex) do
     @moduledoc """
     This implements Interval support for Postgrex that used to be in Ecto but no longer is.
     """
-    @behaviour Ecto.Type
+    if macro_exported?(Ecto.Type, :__using__, 1) do
+      use Ecto.Type
+    else
+      @behaviour Ecto.Type
+    end
 
     @impl true
     def type, do: Postgrex.Interval


### PR DESCRIPTION
…he __using__ macro is available default to newer convenience method that implements these callbacks

@OvermindDL1 Fixes compilation warnings for `ecto_interval` LMKWYT.