### PR TITLE
Allow for Postgrex version 0.16

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule EctoInterval.Mixfile do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:postgrex, "~> 0.14.0 or ~> 0.15.0", optional: true},
+      {:postgrex, "~> 0.14.0 or ~> 0.15.0 or ~> 0.16.0", optional: true},
       {:ecto, "~> 3.0", optional: true},
       {:phoenix_html, "~> 3.0", optional: true}
     ]


### PR DESCRIPTION
Hi,
Currently, ecto_interval is only compatible with postgrex versions 0.14 and 0.15. I have tested  it with postgrex 0.16 and it seems to work fine as well. I certainly not have tested it extensively though.

postgrex [changelog](https://github.com/elixir-ecto/postgrex/blob/master/CHANGELOG.md#v0160-2022-01-23).